### PR TITLE
Add "array" and "error" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,26 @@ The name of the event you want to watch.
 
 #### options
 
+##### array
+
+Type: `boolean`
+Default: `undefined`
+
+This option controls how a listener's parameters are resolved by
+its promise.
+
+If true, the parameters are resolved as an array. If false,
+the first parameter is resolved. If undefined (the default),
+an array is resolved if there's more than one parameter;
+otherwise, the first parameter is resolved.
+
+##### error
+
+Type: `string`
+Default: `"error"`
+
+The name of the event which rejects the promise.
+
 ##### ignoreErrors
 
 Type: `boolean`


### PR DESCRIPTION
##### array

forces the listener's parameters to be resolved as an array rather than a single value.

default: `undefined`
##### error

allows the name of the error event to be specified.

default: `"error"`
